### PR TITLE
Update to use vctrs type errors, not cast errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     methods,
     Rcpp,
     rlang (>= 0.4.0),
-    vctrs (>= 0.2.2)
+    vctrs (>= 0.2.99.9011)
 Suggests: 
     knitr,
     rmarkdown,
@@ -35,7 +35,8 @@ LinkingTo:
 VignetteBuilder: 
     knitr
 Remotes: 
-    RcppCore/Rcpp@20e462f
+    RcppCore/Rcpp@20e462f,
+    r-lib/vctrs
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/tests/testthat/test-ip_interface.R
+++ b/tests/testthat/test-ip_interface.R
@@ -32,8 +32,8 @@ test_that("casting works", {
   expect_equal(vec_cast(ip_interface("192.168.0.1/10"), character()), "192.168.0.1/10")
   expect_equal(vec_cast("192.168.0.1/10", ip_interface()), ip_interface("192.168.0.1/10"))
 
-  expect_error(vec_cast(ip_address("192.168.0.1"), ip_interface()), class = "vctrs_error_incompatible_cast")
-  expect_error(vec_cast(ip_network("192.128.0.0/10"), ip_interface()), class = "vctrs_error_incompatible_cast")
+  expect_error(vec_cast(ip_address("192.168.0.1"), ip_interface()), class = "vctrs_error_incompatible_type")
+  expect_error(vec_cast(ip_network("192.128.0.0/10"), ip_interface()), class = "vctrs_error_incompatible_type")
 })
 
 test_that("coercion works", {


### PR DESCRIPTION
See  https://github.com/r-lib/vctrs/pull/983 for full details.

The development version of vctrs now throws `vctrs_error_incompatible_type` errors when casting is not allowed, rather than `vctrs_error_incompatible_cast`. This better aligns `vec_ptype2()` and `vec_cast()` now that they share the same coercion hierarchy (another new change in the development version, see the NEWS for full details!).