### PR TITLE
Use CRAN version of Rcpp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ LinkingTo:
 VignetteBuilder: 
     knitr
 Remotes: 
-    RcppCore/Rcpp@20e462f,
     r-lib/vctrs
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
Now that Rcpp 1.0.4.6 has been released.