### PR TITLE
ip_to_integer() gains 'base' parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # ipaddress (development version)
 
-* Fixed comparison operators for `ip_network()` and `ip_interface()`
-  * `ip_network()` vectors compare network address before prefix length
-  * `ip_interface()` vectors compare network before host address
+* Comparison of `ip_network()` and `ip_interface()` vectors is now consistent with the Python ipaddress module
+  * `ip_network()`: network address compared before prefix length
+  * `ip_interface()`: network compared before host address
+* `ip_to_integer()` gains a `base` parameter to select between decimal, hexadecimal and binary outputs
 
 
 # ipaddress 0.4.0

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,8 +17,8 @@ wrap_decode_bytes <- function(x) {
     .Call(`_ipaddress_wrap_decode_bytes`, x)
 }
 
-wrap_encode_integer <- function(x) {
-    .Call(`_ipaddress_wrap_encode_integer`, x)
+wrap_encode_integer <- function(x, hex) {
+    .Call(`_ipaddress_wrap_encode_integer`, x, hex)
 }
 
 wrap_decode_integer <- function(x, is_ipv6) {

--- a/R/other_repr.R
+++ b/R/other_repr.R
@@ -39,6 +39,8 @@
 #' @param x
 #'  * For `ip_to_integer()`: An [`ip_address`] vector
 #'  * For `integer_to_ip()`: A character vector
+#' @param base A string choosing the numeric base of the output. Choices are
+#'   decimal (`"dec"`; the default), hexadecimal (`"hex"`), and binary (`"bin"`).
 #' @param is_ipv6 A logical vector indicating whether to construct an IPv4 or
 #'   IPv6 address. If `NULL` (the default), then integers less than 2^32 will
 #'   construct an IPv4 address and anything larger will construct an IPv6 address.
@@ -56,17 +58,25 @@
 #' # with IPv4 only, we can use numeric data type
 #' as.numeric(ip_to_integer(ip_address("192.168.0.1")))
 #'
-#' integer_to_ip(as.character(3232235521))
+#' integer_to_ip(3232235521)
+#'
+#' # hex representation
+#' ip_to_integer(x, base = "hex")
 #' @seealso
 #'  * [ip_to_bytes()] and [bytes_to_ip()]
 #'  * [ip_to_binary()] and [binary_to_ip()]
 #' @export
-ip_to_integer <- function(x) {
+ip_to_integer <- function(x, base = c("dec", "hex", "bin")) {
   if (!is_ip_address(x)) {
     abort("'x' must be an ip_address vector")
   }
 
-  wrap_encode_integer(x)
+  switch(
+    arg_match(base),
+    dec = wrap_encode_integer(x, FALSE),
+    hex = wrap_encode_integer(x, TRUE),
+    bin = wrap_encode_binary(x)
+  )
 }
 
 #' @rdname ip_to_integer

--- a/man/ip_to_integer.Rd
+++ b/man/ip_to_integer.Rd
@@ -5,7 +5,7 @@
 \alias{integer_to_ip}
 \title{Represent address as integer}
 \usage{
-ip_to_integer(x)
+ip_to_integer(x, base = c("dec", "hex", "bin"))
 
 integer_to_ip(x, is_ipv6 = NULL)
 }
@@ -14,6 +14,9 @@ integer_to_ip(x, is_ipv6 = NULL)
 \item For \code{ip_to_integer()}: An \code{\link{ip_address}} vector
 \item For \code{integer_to_ip()}: A character vector
 }}
+
+\item{base}{A string choosing the numeric base of the output. Choices are
+decimal (\code{"dec"}; the default), hexadecimal (\code{"hex"}), and binary (\code{"bin"}).}
 
 \item{is_ipv6}{A logical vector indicating whether to construct an IPv4 or
 IPv6 address. If \code{NULL} (the default), then integers less than 2^32 will
@@ -72,7 +75,10 @@ integer_to_ip(ip_to_integer(x))
 # with IPv4 only, we can use numeric data type
 as.numeric(ip_to_integer(ip_address("192.168.0.1")))
 
-integer_to_ip(as.character(3232235521))
+integer_to_ip(3232235521)
+
+# hex representation
+ip_to_integer(x, base = "hex")
 }
 \seealso{
 \itemize{

--- a/src/IpAddressVector.cpp
+++ b/src/IpAddressVector.cpp
@@ -451,7 +451,7 @@ List IpAddressVector::encodeBytes() const {
   return output;
 }
 
-CharacterVector IpAddressVector::encodeInteger() const {
+CharacterVector IpAddressVector::encodeInteger(bool hex) const {
   std::size_t vsize = is_na.size();
 
   // initialize vectors
@@ -465,9 +465,9 @@ CharacterVector IpAddressVector::encodeInteger() const {
     if (is_na[i]) {
       output[i] = NA_STRING;
     } else if (is_ipv6[i]) {
-      output[i] = encode_integer(address_v6[i]);
+      output[i] = encode_integer(address_v6[i], hex);
     } else {
-      output[i] = encode_integer(address_v4[i]);
+      output[i] = encode_integer(address_v4[i], hex);
     }
   }
 

--- a/src/IpAddressVector.h
+++ b/src/IpAddressVector.h
@@ -79,7 +79,7 @@ public:
   Rcpp::List encodeBytes() const;
 
   // Encode to integer string
-  Rcpp::CharacterVector encodeInteger() const;
+  Rcpp::CharacterVector encodeInteger(bool hex) const;
 
   // Encode to binary string
   Rcpp::CharacterVector encodeBinary() const;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -50,13 +50,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // wrap_encode_integer
-CharacterVector wrap_encode_integer(List x);
-RcppExport SEXP _ipaddress_wrap_encode_integer(SEXP xSEXP) {
+CharacterVector wrap_encode_integer(List x, bool hex);
+RcppExport SEXP _ipaddress_wrap_encode_integer(SEXP xSEXP, SEXP hexSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< List >::type x(xSEXP);
-    rcpp_result_gen = Rcpp::wrap(wrap_encode_integer(x));
+    Rcpp::traits::input_parameter< bool >::type hex(hexSEXP);
+    rcpp_result_gen = Rcpp::wrap(wrap_encode_integer(x, hex));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -502,7 +503,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ipaddress_wrap_print_address", (DL_FUNC) &_ipaddress_wrap_print_address, 1},
     {"_ipaddress_wrap_encode_bytes", (DL_FUNC) &_ipaddress_wrap_encode_bytes, 1},
     {"_ipaddress_wrap_decode_bytes", (DL_FUNC) &_ipaddress_wrap_decode_bytes, 1},
-    {"_ipaddress_wrap_encode_integer", (DL_FUNC) &_ipaddress_wrap_encode_integer, 1},
+    {"_ipaddress_wrap_encode_integer", (DL_FUNC) &_ipaddress_wrap_encode_integer, 2},
     {"_ipaddress_wrap_decode_integer", (DL_FUNC) &_ipaddress_wrap_decode_integer, 2},
     {"_ipaddress_wrap_encode_binary", (DL_FUNC) &_ipaddress_wrap_encode_binary, 1},
     {"_ipaddress_wrap_decode_binary", (DL_FUNC) &_ipaddress_wrap_decode_binary, 1},

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -57,11 +57,12 @@ Address decode_binary(const std::string &bit_string) {
 }
 
 template<class Address>
-std::string encode_integer(const Address &x) {
+std::string encode_integer(const Address &x, bool hex) {
   typename Address::bytes_type x_bytes = x.to_bytes();
+  const std::size_t n_bits = 8*sizeof(x_bytes);
 
   boost::multiprecision::number<boost::multiprecision::cpp_int_backend<
-    8*sizeof(x_bytes), 8*sizeof(x_bytes),
+    n_bits, n_bits,
     boost::multiprecision::unsigned_magnitude,
     boost::multiprecision::checked,
     void
@@ -70,7 +71,13 @@ std::string encode_integer(const Address &x) {
   // import most-significant byte first (x_bytes stored in network order)
   import_bits(x_int, x_bytes.begin(), x_bytes.end(), 8, true);
 
-  return x_int.str();
+  if (hex) {
+    std::stringstream ss;
+    ss << "0x" << std::hex << std::setfill('0') << std::setw(n_bits/4) << std::uppercase <<  x_int;
+    return ss.str();
+  } else {
+    return x_int.str();
+  }
 }
 
 template<class Address>

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -28,8 +28,8 @@ List wrap_decode_bytes(List x) {
 }
 
 // [[Rcpp::export]]
-CharacterVector wrap_encode_integer(List x) {
-  return IpAddressVector(x).encodeInteger();
+CharacterVector wrap_encode_integer(List x, bool hex) {
+  return IpAddressVector(x).encodeInteger(hex);
 }
 
 // [[Rcpp::export]]

--- a/tests/testthat/test-other_repr.R
+++ b/tests/testthat/test-other_repr.R
@@ -8,10 +8,21 @@ test_that("integer encoding/decoding works", {
 
   expect_type(ip_to_integer(x), "character")
   expect_s3_class(integer_to_ip("1"), "ip_address")
+
   expect_equal(
     ip_to_integer(x),
     c("3232235521", "42540766411282592856904136881884656436", NA)
   )
+  expect_equal(
+    ip_to_integer(x, base = "hex"),
+    c("0xC0A80001", "0x20010DB80000000000008A2E03707334", NA)
+  )
+  expect_equal(ip_to_integer(x, base = "bin"), ip_to_binary(x))
+
+  # zero padding
+  expect_equal(ip_to_integer(ip_address("0.0.0.0"), base = "hex"), paste0("0x", strrep("0", 8)))
+  expect_equal(ip_to_integer(ip_address("::"), base = "hex"), paste0("0x", strrep("0", 32)))
+
   expect_equal(integer_to_ip("1", is_ipv6 = NULL), ip_address("0.0.0.1"))
   expect_equal(integer_to_ip("1", is_ipv6 = c(FALSE, TRUE)), ip_address(c("0.0.0.1", "::1")))
   expect_equal(integer_to_ip(ip_to_integer(x)), x)
@@ -54,7 +65,11 @@ test_that("binary encoding/decoding works", {
   ))
   expect_equal(binary_to_ip(ip_to_binary(x)), x)
 
-  expect_warning(binary_to_ip("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), "contains non-binary characters")
+  # zero padding
+  expect_equal(ip_to_binary(ip_address("0.0.0.0")), strrep("0", 32))
+  expect_equal(ip_to_binary(ip_address("::")), strrep("0", 128))
+
+  expect_warning(binary_to_ip(strrep("a", 32)), "contains non-binary characters")
   expect_warning(binary_to_ip("11000000"), "incorrect number of bits")
   expect_warning(binary_to_ip("110000001010100000000000000000010"), "incorrect number of bits")
 })


### PR DESCRIPTION
The `base` parameter allows you select between decimal, hexadecimal and binary outputs.