### PR TITLE
Refactor how reserved networks are tested

### DIFF
--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -1,3 +1,11 @@
+#' Expectation: does the function identify the reserved address range?
+#'
+#' This tests the addresses either side of the reserved network boundaries.
+#'
+#' @param reserved_func The function under test. This should return `TRUE` when
+#'   an [`ip_address`] is within the reserved network.
+#' @param network The reserved network
+#' @noRd
 expect_reserved_address_range <- function(reserved_func, network) {
   act <- quasi_label(enquo(reserved_func), arg = "reserved_func")
 
@@ -28,6 +36,14 @@ expect_reserved_address_range <- function(reserved_func, network) {
   invisible(act$val)
 }
 
+#' Expectation: does the function identify the reserved network?
+#'
+#' This tests the subnets and supernet of the reserved network.
+#'
+#' @param reserved_func The function under test. This should return `TRUE` when
+#'   an [`ip_network`] is within the reserved network.
+#' @param network The reserved network
+#' @noRd
 expect_reserved_network <- function(reserved_func, network) {
   act <- quasi_label(enquo(reserved_func), arg = "reserved_func")
 
@@ -50,6 +66,12 @@ expect_reserved_network <- function(reserved_func, network) {
   invisible(act$val)
 }
 
+#' Expectation: does the function identify reserved addresses and networks?
+#'
+#' @param reserved_func The function under test. This should return `TRUE` when
+#'   an [`ip_address`] or [`ip_network`] is within the reserved network.
+#' @param network The reserved network
+#' @noRd
 expect_reserved <- function(reserved_func, network) {
   func <- enquo(reserved_func)
   expect_reserved_address_range(!!func, network)

--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -1,0 +1,57 @@
+expect_reserved_address_range <- function(reserved_func, network) {
+  act <- quasi_label(enquo(reserved_func), arg = "reserved_func")
+
+  block_start <- network_address(network)
+  block_end <- broadcast_address(network)
+  space_start <- ip_address(c("0.0.0.0", "::"))
+  space_end <- ip_address(c("255.255.255.255", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"))
+
+  boundaries <- vec_c(
+    if (all(block_start != space_start)) block_start - 1,
+    block_start,
+    block_end,
+    if (all(block_end != space_end)) block_end + 1
+  )
+
+  expected <- c(
+    if (all(block_start != space_start)) FALSE,
+    TRUE,
+    TRUE,
+    if (all(block_end != space_end)) FALSE
+  )
+
+  expect(
+    all(act$val(boundaries) == expected),
+    sprintf("%s doesn't match address range '%s'", act$lab, as.character(network))
+  )
+
+  invisible(act$val)
+}
+
+expect_reserved_network <- function(reserved_func, network) {
+  act <- quasi_label(enquo(reserved_func), arg = "reserved_func")
+
+  other_networks <- vec_c(
+    network,
+    if (prefix_length(network) != max_prefix_length(network)) subnets(network),
+    if (prefix_length(network) != 0) supernet(network)
+  )
+  expected <- c(
+    TRUE,
+    if (prefix_length(network) != max_prefix_length(network)) c(TRUE, TRUE),
+    if (prefix_length(network) != 0) FALSE
+  )
+
+  expect(
+    all(act$val(other_networks) == expected),
+    sprintf("%s doesn't match network '%s'", act$lab, as.character(network))
+  )
+
+  invisible(act$val)
+}
+
+expect_reserved <- function(reserved_func, network) {
+  func <- enquo(reserved_func)
+  expect_reserved_address_range(!!func, network)
+  expect_reserved_network(!!func, network)
+}

--- a/tests/testthat/test-ipv6_transition.R
+++ b/tests/testthat/test-ipv6_transition.R
@@ -1,21 +1,7 @@
 test_that("IPv4-mapped IPv6 addresses work", {
-  # IPv4: none
   expect_false(is_ipv4_mapped(ip_address("0.0.0.0")))
-  expect_false(is_ipv4_mapped(ip_network("0.0.0.0/32")))
-
-  # IPv6: ::ffff:0.0.0.0/96
-  expect_equal(
-    is_ipv4_mapped(ip_address(c("::fffe:ffff:ffff", "::ffff:0.0.0.0", "::ffff:255.255.255.255", "::1:0:0:0"))),
-    c(FALSE, TRUE, TRUE, FALSE)
-  )
-  expect_equal(
-    is_ipv4_mapped(ip_network(c("::ffff:0.0.0.0/96", "::ffff:0.0.0.0/97", "::fffe:0.0.0.0/95"))),
-    c(TRUE, TRUE, FALSE)
-  )
-  expect_equal(
-    extract_ipv4_mapped(ip_address(c("192.168.0.1", "::ffff:192.0.2.128", "2001:db8::"))),
-    ip_address(c(NA, "192.0.2.128", NA))
-  )
+  expect_false(is_ipv4_mapped(ip_network("0.0.0.0/0")))
+  expect_reserved(is_ipv4_mapped, ip_network("::ffff:0.0.0.0/96"))
 
   expect_equal(is_ipv4_mapped(ip_address()), logical())
   expect_equal(is_ipv4_mapped(ip_network()), logical())
@@ -32,23 +18,9 @@ test_that("IPv4-mapped IPv6 addresses work", {
 })
 
 test_that("6to4 IPv6 addresses work", {
-  # IPv4: none
-  expect_false(is_6to4(ip_address("0.0.0.0")))
-  expect_false(is_6to4(ip_network("0.0.0.0/32")))
-
-  # IPv6: 2002::/16
-  expect_equal(
-    is_6to4(ip_address(c("2001:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "2002::", "2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "2003::"))),
-    c(FALSE, TRUE, TRUE, FALSE)
-  )
-  expect_equal(
-    is_6to4(ip_network(c("2002::/16", "2002::/17", "2000::/15"))),
-    c(TRUE, TRUE, FALSE)
-  )
-  expect_equal(
-    extract_6to4(ip_address(c("192.168.0.1", "2002:c000:0280::", "2001:db8::"))),
-    ip_address(c(NA, "192.0.2.128", NA))
-  )
+  expect_false(is_ipv4_mapped(ip_address("0.0.0.0")))
+  expect_false(is_ipv4_mapped(ip_network("0.0.0.0/0")))
+  expect_reserved(is_6to4, ip_network("2002::/16"))
 
   expect_equal(is_6to4(ip_address()), logical())
   expect_equal(is_6to4(ip_network()), logical())
@@ -65,27 +37,9 @@ test_that("6to4 IPv6 addresses work", {
 })
 
 test_that("Teredo IPv6 addresses work", {
-  # IPv4: none
-  expect_false(is_teredo(ip_address("0.0.0.0")))
-  expect_false(is_teredo(ip_network("0.0.0.0/32")))
-
-  # IPv6: 2001::/32
-  expect_equal(
-    is_teredo(ip_address(c("2000:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "2001::", "2001:0:ffff:ffff:ffff:ffff:ffff:ffff", "2001:1::"))),
-    c(FALSE, TRUE, TRUE, FALSE)
-  )
-  expect_equal(
-    is_teredo(ip_network(c("2001::/32", "2001::/33", "2000::/31"))),
-    c(TRUE, TRUE, FALSE)
-  )
-  expect_equal(
-    extract_teredo_server(ip_address(c("192.168.0.1", "2001:0000:4136:e378:8000:63bf:3fff:fdd2", "2001:db8::"))),
-    ip_address(c(NA, "65.54.227.120", NA))
-  )
-  expect_equal(
-    extract_teredo_client(ip_address(c("192.168.0.1", "2001:0000:4136:e378:8000:63bf:3fff:fdd2", "2001:db8::"))),
-    ip_address(c(NA, "192.0.2.45", NA))
-  )
+  expect_false(is_ipv4_mapped(ip_address("0.0.0.0")))
+  expect_false(is_ipv4_mapped(ip_network("0.0.0.0/0")))
+  expect_reserved(is_teredo, ip_network("2001::/32"))
 
   expect_equal(is_teredo(ip_address()), logical())
   expect_equal(is_teredo(ip_network()), logical())

--- a/tests/testthat/test-reserved.R
+++ b/tests/testthat/test-reserved.R
@@ -1,44 +1,6 @@
-check_reserved <- function(check_func, net) {
-
-  # check ip_address version of function
-  net_start <- network_address(net)
-  net_end <- broadcast_address(net)
-  space_start <- ip_address(c("0.0.0.0", "::"))
-  space_end <- ip_address(c("255.255.255.255", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"))
-
-  boundaries <- vec_c(
-    if (all(net_start != space_start)) net_start - 1,
-    net_start,
-    net_end,
-    if (all(net_end != space_end)) net_end + 1
-  )
-  expected <- c(
-    if (all(net_start != space_start)) FALSE,
-    TRUE,
-    TRUE,
-    if (all(net_end != space_end)) FALSE
-  )
-
-  expect_equal(check_func(boundaries), expected)
-
-  # check ip_network version of function
-  other_networks <- vec_c(
-    net,
-    if (prefix_length(net) != max_prefix_length(net)) subnets(net),
-    if (prefix_length(net) != 0) supernet(net)
-  )
-  expected <- c(
-    TRUE,
-    if (prefix_length(net) != max_prefix_length(net)) c(TRUE, TRUE),
-    if (prefix_length(net) != 0) FALSE
-  )
-
-  expect_equal(check_func(other_networks), expected)
-}
-
 test_that("is_multicast works", {
-  check_reserved(is_multicast, ip_network("224.0.0.0/4"))
-  check_reserved(is_multicast, ip_network("ff00::/8"))
+  expect_reserved(is_multicast, ip_network("224.0.0.0/4"))
+  expect_reserved(is_multicast, ip_network("ff00::/8"))
 
   expect_equal(is_multicast(ip_address()), logical())
   expect_equal(is_multicast(ip_network()), logical())
@@ -50,8 +12,8 @@ test_that("is_multicast works", {
 })
 
 test_that("is_unspecified works", {
-  check_reserved(is_unspecified, ip_network("0.0.0.0/32"))
-  check_reserved(is_unspecified, ip_network("::/128"))
+  expect_reserved(is_unspecified, ip_network("0.0.0.0/32"))
+  expect_reserved(is_unspecified, ip_network("::/128"))
 
   expect_equal(is_unspecified(ip_address()), logical())
   expect_equal(is_unspecified(ip_network()), logical())
@@ -63,8 +25,8 @@ test_that("is_unspecified works", {
 })
 
 test_that("is_loopback works", {
-  check_reserved(is_loopback, ip_network("127.0.0.0/8"))
-  check_reserved(is_loopback, ip_network("::1/128"))
+  expect_reserved(is_loopback, ip_network("127.0.0.0/8"))
+  expect_reserved(is_loopback, ip_network("::1/128"))
 
   expect_equal(is_loopback(ip_address()), logical())
   expect_equal(is_loopback(ip_network()), logical())
@@ -76,8 +38,8 @@ test_that("is_loopback works", {
 })
 
 test_that("is_link_local works", {
-  check_reserved(is_link_local, ip_network("169.254.0.0/16"))
-  check_reserved(is_link_local, ip_network("fe80::/10"))
+  expect_reserved(is_link_local, ip_network("169.254.0.0/16"))
+  expect_reserved(is_link_local, ip_network("fe80::/10"))
 
   expect_equal(is_link_local(ip_address()), logical())
   expect_equal(is_link_local(ip_network()), logical())

--- a/tests/testthat/test-reserved.R
+++ b/tests/testthat/test-reserved.R
@@ -1,23 +1,44 @@
-test_that("is_multicast works", {
-  # IPv4: 224.0.0.0/4
-  expect_equal(
-    is_multicast(ip_address(c("223.255.255.255", "224.0.0.0", "239.255.255.255", "240.0.0.0"))),
-    c(FALSE, TRUE, TRUE, FALSE)
+check_reserved <- function(check_func, net) {
+
+  # check ip_address version of function
+  net_start <- network_address(net)
+  net_end <- broadcast_address(net)
+  space_start <- ip_address(c("0.0.0.0", "::"))
+  space_end <- ip_address(c("255.255.255.255", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"))
+
+  boundaries <- vec_c(
+    if (all(net_start != space_start)) net_start - 1,
+    net_start,
+    net_end,
+    if (all(net_end != space_end)) net_end + 1
   )
-  expect_equal(
-    is_multicast(ip_network(c("224.0.0.0/4", "224.0.0.0/5", "224.0.0.0/3"))),
-    c(TRUE, TRUE, FALSE)
+  expected <- c(
+    if (all(net_start != space_start)) FALSE,
+    TRUE,
+    TRUE,
+    if (all(net_end != space_end)) FALSE
   )
 
-  # IPv6: ff00::/8
-  expect_equal(
-    is_multicast(ip_address(c("feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "ff00::", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"))),
-    c(FALSE, TRUE, TRUE)
+  expect_equal(check_func(boundaries), expected)
+
+  # check ip_network version of function
+  other_networks <- vec_c(
+    net,
+    if (prefix_length(net) != max_prefix_length(net)) subnets(net),
+    if (prefix_length(net) != 0) supernet(net)
   )
-  expect_equal(
-    is_multicast(ip_network(c("ff00::/8", "ff00::/9", "fe00::/7"))),
-    c(TRUE, TRUE, FALSE)
+  expected <- c(
+    TRUE,
+    if (prefix_length(net) != max_prefix_length(net)) c(TRUE, TRUE),
+    if (prefix_length(net) != 0) FALSE
   )
+
+  expect_equal(check_func(other_networks), expected)
+}
+
+test_that("is_multicast works", {
+  check_reserved(is_multicast, ip_network("224.0.0.0/4"))
+  check_reserved(is_multicast, ip_network("ff00::/8"))
 
   expect_equal(is_multicast(ip_address()), logical())
   expect_equal(is_multicast(ip_network()), logical())
@@ -29,25 +50,8 @@ test_that("is_multicast works", {
 })
 
 test_that("is_unspecified works", {
-  # IPv4: 0.0.0.0
-  expect_equal(
-    is_unspecified(ip_address(c("0.0.0.0", "0.0.0.1"))),
-    c(TRUE, FALSE)
-  )
-  expect_equal(
-    is_unspecified(ip_network(c("0.0.0.0/32", "0.0.0.0/31"))),
-    c(TRUE, FALSE)
-  )
-
-  # IPv6: ::
-  expect_equal(
-    is_unspecified(ip_address(c("::", "::1"))),
-    c(TRUE, FALSE)
-  )
-  expect_equal(
-    is_unspecified(ip_network(c("::/128", "::/127"))),
-    c(TRUE, FALSE)
-  )
+  check_reserved(is_unspecified, ip_network("0.0.0.0/32"))
+  check_reserved(is_unspecified, ip_network("::/128"))
 
   expect_equal(is_unspecified(ip_address()), logical())
   expect_equal(is_unspecified(ip_network()), logical())
@@ -59,25 +63,8 @@ test_that("is_unspecified works", {
 })
 
 test_that("is_loopback works", {
-  # IPv4: 127.0.0.0/8
-  expect_equal(
-    is_loopback(ip_address(c("126.255.255.255", "127.0.0.0", "127.255.255.255", "128.0.0.0"))),
-    c(FALSE, TRUE, TRUE, FALSE)
-  )
-  expect_equal(
-    is_loopback(ip_network(c("127.0.0.0/8", "127.0.0.0/9", "126.0.0.0/7"))),
-    c(TRUE, TRUE, FALSE)
-  )
-
-  # IPv6: ::1/128
-  expect_equal(
-    is_loopback(ip_address(c("::", "::1", "::2"))),
-    c(FALSE, TRUE, FALSE)
-  )
-  expect_equal(
-    is_loopback(ip_network(c("::1/128", "::/127"))),
-    c(TRUE, FALSE)
-  )
+  check_reserved(is_loopback, ip_network("127.0.0.0/8"))
+  check_reserved(is_loopback, ip_network("::1/128"))
 
   expect_equal(is_loopback(ip_address()), logical())
   expect_equal(is_loopback(ip_network()), logical())
@@ -89,25 +76,8 @@ test_that("is_loopback works", {
 })
 
 test_that("is_link_local works", {
-  # IPv4: 169.254.0.0/16
-  expect_equal(
-    is_link_local(ip_address(c("169.253.255.255", "169.254.0.0", "169.254.255.255", "169.255.0.0"))),
-    c(FALSE, TRUE, TRUE, FALSE)
-  )
-  expect_equal(
-    is_link_local(ip_network(c("169.254.0.0/16", "169.254.0.0/17", "169.254.0.0/15"))),
-    c(TRUE, TRUE, FALSE)
-  )
-
-  # IPv6: fe80::/10
-  expect_equal(
-    is_link_local(ip_address(c("fe7f:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "fe80::", "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "fec0::"))),
-    c(FALSE, TRUE, TRUE, FALSE)
-  )
-  expect_equal(
-    is_link_local(ip_network(c("fe80::/10", "fe80::/11", "fe80::/9"))),
-    c(TRUE, TRUE, FALSE)
-  )
+  check_reserved(is_link_local, ip_network("169.254.0.0/16"))
+  check_reserved(is_link_local, ip_network("fe80::/10"))
 
   expect_equal(is_link_local(ip_address()), logical())
   expect_equal(is_link_local(ip_network()), logical())


### PR DESCRIPTION
Added `expect_reserved()` internal function, which can be used like:
* `expect_reserved(is_multicast, ip_network("ff00::/8"))`

It will check both the `ip_address()` and `ip_network()` versions of the function argument.