### PR TITLE
Fix comparison of ip_address vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 ## Minor improvements and fixes
 
 * `ip_to_integer()` gains a `base` parameter to select between decimal, hexadecimal and binary outputs
+* Fixed comparison of `ip_address()` vectors (previously did not account for machine endianness)
 * Comparison of `ip_network()` and `ip_interface()` vectors is now consistent with the Python ipaddress module
   * `ip_network()`: network address compared before prefix length
   * `ip_interface()`: network compared before host address

--- a/src/basic.cpp
+++ b/src/basic.cpp
@@ -55,19 +55,19 @@ DataFrame wrap_compare_address(List address_r) {
       out_v6[i] = NA_LOGICAL;
     } else if (address.is_ipv6[i]) {
       r_address_v6_type bytes = encode_r<r_address_v6_type>(address.address_v6[i]);
-      out_addr1[i] = (bytes[0] & left_mask) >> 16;
-      out_addr2[i] = (bytes[0] & right_mask);
-      out_addr3[i] = (bytes[1] & left_mask) >> 16;
-      out_addr4[i] = (bytes[1] & right_mask);
-      out_addr5[i] = (bytes[2] & left_mask) >> 16;
-      out_addr6[i] = (bytes[2] & right_mask);
-      out_addr7[i] = (bytes[3] & left_mask) >> 16;
-      out_addr8[i] = (bytes[3] & right_mask);
+      out_addr1[i] = (ntohl(bytes[0]) & left_mask) >> 16;
+      out_addr2[i] = (ntohl(bytes[0]) & right_mask);
+      out_addr3[i] = (ntohl(bytes[1]) & left_mask) >> 16;
+      out_addr4[i] = (ntohl(bytes[1]) & right_mask);
+      out_addr5[i] = (ntohl(bytes[2]) & left_mask) >> 16;
+      out_addr6[i] = (ntohl(bytes[2]) & right_mask);
+      out_addr7[i] = (ntohl(bytes[3]) & left_mask) >> 16;
+      out_addr8[i] = (ntohl(bytes[3]) & right_mask);
       out_v6[i] = true;
     } else {
       r_address_v4_type bytes = encode_r<r_address_v4_type>(address.address_v4[i]);
-      out_addr1[i] = (bytes[0] & left_mask) >> 16;
-      out_addr2[i] = (bytes[0] & right_mask);
+      out_addr1[i] = (ntohl(bytes[0]) & left_mask) >> 16;
+      out_addr2[i] = (ntohl(bytes[0]) & right_mask);
     }
   }
 

--- a/tests/testthat/test-ip_address_v4.R
+++ b/tests/testthat/test-ip_address_v4.R
@@ -52,4 +52,7 @@ test_that("comparison operations work", {
     c(-1L, rep(1L, length(x) - 1L))
   )
   expect_equal(vec_compare(ip_address("192.168.0.1"), ip_address(NA)), NA_integer_)
+
+  # not effected by machine byte-endianness
+  expect_true(ip_address("255.128.0.0") > ip_address("0.0.128.255"))
 })

--- a/tests/testthat/test-ip_address_v6.R
+++ b/tests/testthat/test-ip_address_v6.R
@@ -40,4 +40,7 @@ test_that("comparison operations work", {
     c(-1L, rep(1L, length(x) - 1L))
   )
   expect_equal(vec_compare(ip_address("2001:db8::8a2e:370:7334"), ip_address(NA)), NA_integer_)
+
+  # not effected by machine byte-endianness
+  expect_true(ip_address("256::") > ip_address("0:128::"))
 })


### PR DESCRIPTION
On little-endian machines, the byte order used by asio classes disagrees with the byte order for integer types.

I did originally use `ntohl()` in the encoding functions, but removed it because it was an unnecessary operation (for a very frequently used function). This means R stores the data bytes in network order, not host order. But when we do comparisons, we do need the bytes in host order.