### PR TITLE
Conditional use of fuzzyjoin in vignette

### DIFF
--- a/vignettes/ipaddress-examples.Rmd
+++ b/vignettes/ipaddress-examples.Rmd
@@ -87,7 +87,7 @@ my_addresses %>%
 But what if we need to know _which_ of our networks the address was found in?
 We can do that using the excellent [fuzzyjoin](https://cran.r-project.org/package=fuzzyjoin) package together with the `is_within()` function.
 
-```{r}
+```{r, eval=rlang::is_installed("fuzzyjoin")}
 my_addresses %>%
   fuzzyjoin::fuzzy_left_join(my_networks, c("address" = "network"), is_within)
 ```


### PR DESCRIPTION
Getting WARN in CRAN checks because the vignette unconditionally uses a package in Suggests.

```
checking re-building of vignette outputs ... [4s/6s] WARNING
Error(s) in re-building vignettes:
  ...
--- re-building 'ipaddress-classes.Rmd' using rmarkdown
--- finished re-building 'ipaddress-classes.Rmd'

--- re-building 'ipaddress-examples.Rmd' using rmarkdown

Attaching package: 'dplyr'

The following objects are masked from 'package:stats':

    filter, lag

The following objects are masked from 'package:base':

    intersect, setdiff, setequal, union

Quitting from lines 91-93 (ipaddress-examples.Rmd) 
Error: processing vignette 'ipaddress-examples.Rmd' failed with diagnostics:
there is no package called 'fuzzyjoin'
--- failed re-building 'ipaddress-examples.Rmd'

SUMMARY: processing the following file failed:
  'ipaddress-examples.Rmd'

Error: Vignette re-building failed.
Execution halted
```