### PR TITLE
Switch several sprintf to snprintf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,8 +37,6 @@ LinkingTo:
     Rcpp
 VignetteBuilder: 
     knitr
-Remotes: 
-    eddelbuettel/asioheaders
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,8 @@ LinkingTo:
     Rcpp
 VignetteBuilder: 
     knitr
+Remotes: 
+    eddelbuettel/asioheaders
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/src/ip_address.cpp
+++ b/src/ip_address.cpp
@@ -63,8 +63,8 @@ CharacterVector wrap_print_address(List address_r, bool exploded = false) {
     } else if (exploded && address[i].is_ipv6()) {
       char buffer[40];
       auto bytes = address[i].bytes_v6();
-      sprintf(
-        buffer,
+      snprintf(
+        buffer, 40,
         "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
         bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
         bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]

--- a/src/ip_network.cpp
+++ b/src/ip_network.cpp
@@ -144,8 +144,8 @@ CharacterVector wrap_print_network(List network_r, bool exploded = false) {
     } else if (exploded && network[i].is_ipv6()) {
       char buffer[50];
       auto bytes = network[i].address().bytes_v6();
-      sprintf(
-        buffer,
+      snprintf(
+        buffer, 50,
         "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x/%u",
         bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
         bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],

--- a/src/ip_to_hex.cpp
+++ b/src/ip_to_hex.cpp
@@ -83,8 +83,8 @@ CharacterVector wrap_encode_hex(List input) {
     } else if (address[i].is_ipv6()) {
       char buffer[40];
       auto bytes = address[i].bytes_v6();
-      sprintf(
-        buffer,
+      snprintf(
+        buffer, 40,
         "%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
         bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
         bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
@@ -94,8 +94,8 @@ CharacterVector wrap_encode_hex(List input) {
     } else {
       char buffer[10];
       auto bytes = address[i].bytes_v4();
-      sprintf(
-        buffer,
+      snprintf(
+        buffer, 10,
         "%02X%02X%02X%02X",
         bytes[0], bytes[1], bytes[2], bytes[3]
       );

--- a/src/reverse_pointer.cpp
+++ b/src/reverse_pointer.cpp
@@ -25,8 +25,8 @@ CharacterVector wrap_reverse_pointer(List address_r) {
       output[i] = NA_STRING;
     } else if (address[i].is_ipv6()) {
       auto bytes = address[i].bytes_v6();
-      sprintf(
-        buffer,
+      snprintf(
+        buffer, 40,
         "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
         bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
         bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
@@ -39,8 +39,8 @@ CharacterVector wrap_reverse_pointer(List address_r) {
       output[i] = os.str() + "ip.arpa";
     } else {
       auto bytes = address[i].bytes_v4();
-      sprintf(
-        buffer,
+      snprintf(
+        buffer, 40,
         "%i.%i.%i.%i.in-addr.arpa",
         bytes[3], bytes[2], bytes[1], bytes[0]
       );


### PR DESCRIPTION
Via [this issue ticket](https://github.com/eddelbuettel/asioheaders/issues/8) Winston shared with me an email from CRAN / BDR about (v)?sprintf being detected now, with some leads into AsioHeaders. I have just uploaded a new version of AsioHeaders to CRAN which should hopefully progress smoothly.

ipaddress had issues of its own which were easy to fix and are addressed here by switching the sprintf to snprintf.